### PR TITLE
Check if  rpc servers have changed.

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -59,6 +59,7 @@ type llmServer struct {
 	loadProgress float32
 
 	sem *semaphore.Weighted
+	servers []string // List of servers at instantiaton
 }
 
 // LoadModel will load a model from disk. The model must be in the GGML format.
@@ -363,6 +364,7 @@ func NewLlamaServer(gpus gpu.GpuInfoList, model string, ggml *GGML, adapters, pr
 			totalLayers: ggml.KV().BlockCount() + 1,
 			gpus:        gpus,
 			done:        make(chan error, 1),
+			servers:	 getAvailableServers() 
 		}
 
 		s.cmd.Env = os.Environ()

--- a/llm/server.go
+++ b/llm/server.go
@@ -59,7 +59,7 @@ type llmServer struct {
 	loadProgress float32
 
 	sem *semaphore.Weighted
-	servers []string // List of servers at instantiaton
+	servers map[string]string // List of servers at instantiaton
 }
 
 // LoadModel will load a model from disk. The model must be in the GGML format.

--- a/server/sched.go
+++ b/server/sched.go
@@ -602,7 +602,7 @@ func (runner *runnerRef) needsReload(ctx context.Context, req *LlmRequest) bool 
 	if !reflect.DeepEqual(runner.model.AdapterPaths, req.model.AdapterPaths) || // have the adapters changed?
 		!reflect.DeepEqual(runner.model.ProjectorPaths, req.model.ProjectorPaths) || // have the projectors changed?
 		!reflect.DeepEqual(optsExisting, optsNew) || // have the runner options changed?
-		runner.llama.servers != getAvailableServers() || // have RPC servers changed?
+		!reflect.DeepEqual(runner.llama.servers, getAvailableServers()) || // have RPC servers changed?
 		runner.llama.Ping(ctx) != nil {
 		return true
 	}

--- a/server/sched.go
+++ b/server/sched.go
@@ -602,6 +602,7 @@ func (runner *runnerRef) needsReload(ctx context.Context, req *LlmRequest) bool 
 	if !reflect.DeepEqual(runner.model.AdapterPaths, req.model.AdapterPaths) || // have the adapters changed?
 		!reflect.DeepEqual(runner.model.ProjectorPaths, req.model.ProjectorPaths) || // have the projectors changed?
 		!reflect.DeepEqual(optsExisting, optsNew) || // have the runner options changed?
+		runner.llama.servers != getAvailableServers() || // have RPC servers changed?
 		runner.llama.Ping(ctx) != nil {
 		return true
 	}


### PR DESCRIPTION
This adds a simple check to see if the servers changed from when the llmServer was first created.